### PR TITLE
fix: add transitional mesa-(va,vdpau)-drivers packages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -229,6 +229,22 @@ Description: shared infrastructure for Mesa drivers
  multiple Mesa drivers. This library is an implementation detail of Mesa
  and should not be used directly by user code.
 
+Package: mesa-va-drivers
+Section: libs
+Architecture: linux-any
+Depends: mesa-libgallium
+Multi-Arch: same
+Description: Transitional package (safe to remove)
+ This package has been replaced by mesa-libgallium.
+
+Package: mesa-vdpau-drivers
+Section: libs
+Architecture: linux-any
+Depends: mesa-libgallium
+Multi-Arch: same
+Description: Transitional package (safe to remove)
+ This package has been replaced by mesa-libgallium.
+
 Package: mesa-teflon-delegate
 Section: libs
 Architecture: arm64

--- a/debian/control.in
+++ b/debian/control.in
@@ -229,6 +229,22 @@ Description: shared infrastructure for Mesa drivers
  multiple Mesa drivers. This library is an implementation detail of Mesa
  and should not be used directly by user code.
 
+Package: mesa-va-drivers
+Section: libs
+Architecture: linux-any
+Depends: mesa-libgallium
+Multi-Arch: same
+Description: Transitional package (safe to remove)
+ This package has been replaced by mesa-libgallium.
+
+Package: mesa-vdpau-drivers
+Section: libs
+Architecture: linux-any
+Depends: mesa-libgallium
+Multi-Arch: same
+Description: Transitional package (safe to remove)
+ This package has been replaced by mesa-libgallium.
+
 Package: mesa-teflon-delegate
 Section: libs
 Architecture: arm64


### PR DESCRIPTION
Should fix the COSMIC Store error installing the Mesa update since https://github.com/pop-os/desktop/pull/152 is not enough to work around the underlying PackageKit bug(s).

Should also have the side effect of allowing a normal `apt upgrade`, even though the `full-upgrade` requirement itself was not the underlying cause of the error.